### PR TITLE
Convert code to Swift 2.0

### DIFF
--- a/Chart/Chart.swift
+++ b/Chart/Chart.swift
@@ -12,11 +12,11 @@ protocol ChartDelegate {
     /**
     Tells the delegate that the specified chart has been touched.
     
-    :param: chart The chart that has been touched.
-    :param: indexes Each element of this array contains the index of the data that has been touched, one for each series.
+    - parameter chart: The chart that has been touched.
+    - parameter indexes: Each element of this array contains the index of the data that has been touched, one for each series.
             If the series hasn't been touched, its index will be nil.
-    :param: x The value on the x-axis that has been touched.
-    :param: left The distance from the left side of the chart.
+    - parameter x: The value on the x-axis that has been touched.
+    - parameter left: The distance from the left side of the chart.
     
     */
     func didTouchChart(chart: Chart, indexes: Array<Int?>, x: Float, left: CGFloat)
@@ -25,7 +25,7 @@ protocol ChartDelegate {
     Tells the delegate that the user finished touching the chart. The user will "finish" touching the
     chart only swiping left/right outside the chart.
     
-    :param: chart The chart that has been touched.
+    - parameter chart: The chart that has been touched.
     
     */
     func didFinishTouchingChart(chart: Chart)
@@ -186,7 +186,7 @@ class Chart: UIControl {
         backgroundColor = UIColor.clearColor()
     }
     
-    required init(coder aDecoder: NSCoder) {
+    required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
@@ -280,12 +280,12 @@ class Chart: UIControl {
         
         // Draw content
         
-        for (index, series) in enumerate(self.series) {
+        for (index, series) in self.series.enumerate() {
             
             // Separate each line in multiple segments over and below the x axis
-            var segments = Chart.segmentLine(series.data as ChartLineSegment)
+            let segments = Chart.segmentLine(series.data as ChartLineSegment)
             
-            for (i, segment) in enumerate(segments) {
+            for (i, segment) in segments.enumerate() {
                 let scaledXValues = scaleValuesOnXAxis( segment.map( { return $0.x } ) )
                 let scaledYValues = scaleValuesOnYAxis( segment.map( { return $0.y } ) )
                 
@@ -326,10 +326,10 @@ class Chart: UIControl {
             let yValues =  series.data.map( { (point: ChartPoint) -> Float in
                 return point.y } )
             
-            let newMinX = minElement(xValues)
-            let newMinY = minElement(yValues)
-            let newMaxX = maxElement(xValues)
-            let newMaxY = maxElement(yValues)
+            let newMinX = xValues.minElement()!
+            let newMinY = yValues.minElement()!
+            let newMaxX = xValues.maxElement()!
+            let newMaxY = yValues.maxElement()!
             
             if min.x == nil || newMinX < min.x! { min.x = newMinX }
             if min.y == nil || newMinY < min.y! { min.y = newMinY }
@@ -340,15 +340,15 @@ class Chart: UIControl {
         // Check in labels
         
         if xLabels != nil {
-            let newMinX = minElement(xLabels!)
-            let newMaxX = maxElement(xLabels!)
+            let newMinX = (xLabels!).minElement()!
+            let newMaxX = (xLabels!).maxElement()!
             if min.x == nil || newMinX < min.x { min.x = newMinX }
             if max.x == nil || newMaxX > max.x { max.x = newMaxX }
         }
         
         if yLabels != nil {
-            let newMinY = minElement(yLabels!)
-            let newMaxY = maxElement(yLabels!)
+            let newMinY = (yLabels!).minElement()!
+            let newMaxY = (yLabels!).maxElement()!
             if min.y == nil || newMinY < min.y { min.y = newMinY }
             if max.y == nil || newMaxY > max.y { max.y = newMaxY }
         }
@@ -411,14 +411,14 @@ class Chart: UIControl {
     private func isVerticalSegmentAboveXAxis(yValues: Array<Float>) -> Bool {
         
         // YValues are "reverted" from top to bottom, so min is actually the maxz
-        let min = maxElement(yValues)
+        let min = yValues.maxElement()!
         let zero = getZeroValueOnYAxis()
         
         return min <= zero
         
     }
     
-    private func drawLine(#xValues: Array<Float>, yValues: Array<Float>, seriesIndex: Int) -> CAShapeLayer {
+    private func drawLine(xValues xValues: Array<Float>, yValues: Array<Float>, seriesIndex: Int) -> CAShapeLayer {
         
         let isAboveXAxis = isVerticalSegmentAboveXAxis(yValues)
         let path = CGPathCreateMutable()
@@ -430,7 +430,7 @@ class Chart: UIControl {
             CGPathAddLineToPoint(path, nil, CGFloat(xValues[i]), CGFloat(y))
         }
         
-        var lineLayer = CAShapeLayer()
+        let lineLayer = CAShapeLayer()
         lineLayer.frame = self.bounds
         lineLayer.path = path
         
@@ -451,7 +451,7 @@ class Chart: UIControl {
         return lineLayer
     }
     
-    private func drawArea(#xValues: Array<Float>, yValues: Array<Float>, seriesIndex: Int) {
+    private func drawArea(xValues xValues: Array<Float>, yValues: Array<Float>, seriesIndex: Int) {
         let isAboveXAxis = isVerticalSegmentAboveXAxis(yValues)
         let area = CGPathCreateMutable()
         let zero = CGFloat(getZeroValueOnYAxis())
@@ -464,7 +464,7 @@ class Chart: UIControl {
         
         CGPathAddLineToPoint(area, nil, CGFloat(xValues.last!), zero)
         
-        var areaLayer = CAShapeLayer()
+        let areaLayer = CAShapeLayer()
         areaLayer.frame = self.bounds
         areaLayer.path = area
         areaLayer.strokeColor = nil
@@ -537,7 +537,7 @@ class Chart: UIControl {
         let scaled = scaleValuesOnXAxis(labels)
         let padding: CGFloat = 5
         
-        for (i, value) in enumerate(scaled) {
+        for (i, value) in scaled.enumerate() {
             let x = CGFloat(value)
 
             
@@ -601,7 +601,7 @@ class Chart: UIControl {
         let scaled = scaleValuesOnYAxis(labels)
         let padding: CGFloat = 5
         let zero = CGFloat(getZeroValueOnYAxis())
-        for (i, value) in enumerate(scaled) {
+        for (i, value) in scaled.enumerate() {
             
             let y = CGFloat(value)
             
@@ -660,7 +660,7 @@ class Chart: UIControl {
             CGPathMoveToPoint(path, nil, left, 0)
             CGPathAddLineToPoint(path, nil, left, drawingHeight + topInset)
             
-            var shapeLayer = CAShapeLayer()
+            let shapeLayer = CAShapeLayer()
             shapeLayer.frame = self.bounds
             shapeLayer.path = path
             shapeLayer.strokeColor = highlightLineColor.CGColor
@@ -711,15 +711,15 @@ class Chart: UIControl {
         delegate!.didTouchChart(self, indexes: indexes, x: x, left: left)
         
     }
-    override func touchesBegan(touches: Set<NSObject>, withEvent event: UIEvent) {
+    override func touchesBegan(touches: Set<UITouch>, withEvent event: UIEvent?) {
         handleTouchEvents(touches, event: event)
     }
     
-    override func touchesEnded(touches: Set<NSObject>, withEvent event: UIEvent) {
+    override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         handleTouchEvents(touches, event: event)
     }
     
-    override func touchesMoved(touches: Set<NSObject>, withEvent event: UIEvent) {
+    override func touchesMoved(touches: Set<UITouch>, withEvent event: UIEvent?) {
         handleTouchEvents(touches, event: event)
     }
     
@@ -739,7 +739,7 @@ class Chart: UIControl {
     private class func findClosestInValues(values: Array<Float>, forValue value: Float) -> (lowestValue: Float?, highestValue: Float?, lowestIndex: Int?, highestIndex: Int?) {
         var lowestValue: Float?, highestValue: Float?, lowestIndex: Int?, highestIndex: Int?
         
-        for (i, currentValue) in enumerate(values) {
+        for (i, currentValue) in values.enumerate() {
             if currentValue <= value && (lowestValue == nil || lowestValue! < currentValue) {
                 lowestValue = currentValue
                 lowestIndex = i
@@ -761,7 +761,7 @@ class Chart: UIControl {
     private class func segmentLine(line: ChartLineSegment) -> Array<ChartLineSegment> {
         var segments: Array<ChartLineSegment> = []
         var segment: ChartLineSegment = []
-        for (i, point) in enumerate(line) {
+        for (i, point) in line.enumerate() {
             segment.append(point)
             if i < line.count - 1 {
                 let nextPoint = line[i+1]

--- a/Chart/Chart.swift
+++ b/Chart/Chart.swift
@@ -285,7 +285,7 @@ class Chart: UIControl {
             // Separate each line in multiple segments over and below the x axis
             let segments = Chart.segmentLine(series.data as ChartLineSegment)
             
-            for (i, segment) in segments.enumerate() {
+            segments.forEach({ segment in
                 let scaledXValues = scaleValuesOnXAxis( segment.map( { return $0.x } ) )
                 let scaledYValues = scaleValuesOnYAxis( segment.map( { return $0.y } ) )
                 
@@ -295,7 +295,7 @@ class Chart: UIControl {
                 if series.area {
                     drawArea(xValues: scaledXValues, yValues: scaledYValues, seriesIndex: index)
                 }
-            }
+            })
         }
         
         drawAxes()

--- a/Chart/ChartColors.swift
+++ b/Chart/ChartColors.swift
@@ -12,9 +12,9 @@ Shorthands for various colors to use freely in the charts.
 */
 struct ChartColors {
     static func colorFromHex(hex: Int) -> UIColor {
-        var red = CGFloat((hex & 0xFF0000) >> 16) / 255.0
-        var green = CGFloat((hex & 0xFF00) >> 8) / 255.0
-        var blue = CGFloat((hex & 0xFF)) / 255.0
+        let red = CGFloat((hex & 0xFF0000) >> 16) / 255.0
+        let green = CGFloat((hex & 0xFF00) >> 8) / 255.0
+        let blue = CGFloat((hex & 0xFF)) / 255.0
         
         return UIColor(red: red, green: green, blue: blue, alpha: 1)
     }

--- a/Chart/ChartSeries.swift
+++ b/Chart/ChartSeries.swift
@@ -23,7 +23,7 @@ class ChartSeries {
     
     init(_ data: Array<Float>) {
         self.data = []
-        for (x, y) in enumerate(data) {
+        for (x, y) in data.enumerate() {
             let point: (x: Float, y: Float) = (x: Float(x), y: y)
             self.data.append(point)
         }

--- a/StockChartViewController.swift
+++ b/StockChartViewController.swift
@@ -39,13 +39,13 @@ class StockChartViewController: UIViewController, ChartDelegate {
         let dateFormatter = NSDateFormatter()
         dateFormatter.dateFormat = "MM"
         
-        for (i, value) in enumerate(stockValues) {
+        for (i, value) in stockValues.enumerate() {
             
             serieData.append(value["close"] as! Float)
             
             // Use only one label for each month
-            let month = dateFormatter.stringFromDate(value["date"] as! NSDate).toInt()!
-            let monthAsString:String = dateFormatter.monthSymbols[month - 1] as! String
+            let month = Int(dateFormatter.stringFromDate(value["date"] as! NSDate))!
+            let monthAsString:String = dateFormatter.monthSymbols[month - 1] 
             if (labels.count == 0 || labelsAsString.last != monthAsString) {
                 labels.append(Float(i))
                 labelsAsString.append(monthAsString)
@@ -66,7 +66,7 @@ class StockChartViewController: UIViewController, ChartDelegate {
         chart.xLabelsTextAlignment = .Center
         chart.yLabelsOnRightSide = true
         // Add some padding above the x-axis
-        chart.minY = minElement(serieData) - 5
+        chart.minY = serieData.minElement()! - 5
         
         chart.addSeries(series)
         
@@ -113,13 +113,13 @@ class StockChartViewController: UIViewController, ChartDelegate {
         // Read the JSON file
         let filePath = NSBundle.mainBundle().pathForResource("AAPL", ofType: "json")!
         let jsonData = NSData(contentsOfFile: filePath)
-        let json: NSDictionary = NSJSONSerialization.JSONObjectWithData(jsonData!, options: nil, error: nil) as! NSDictionary
+        let json: NSDictionary = (try! NSJSONSerialization.JSONObjectWithData(jsonData!, options: [])) as! NSDictionary
         let jsonValues = json["quotes"] as! Array<NSDictionary>
         
         // Parse data
         let dateFormatter = NSDateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
-        var values = jsonValues.map() { (value: NSDictionary) -> Dictionary<String, Any> in
+        let values = jsonValues.map() { (value: NSDictionary) -> Dictionary<String, Any> in
             let date = dateFormatter.dateFromString(value["date"]! as! String)
             let close = (value["close"]! as! NSNumber).floatValue
             return ["date": date!, "close": close]

--- a/SwiftChart.xcodeproj/project.pbxproj
+++ b/SwiftChart.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		2404EEA31A0D5AE800BCB7D6 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0710;
+				LastSwiftUpdateCheck = 0710;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Giampaolo Bellavite";
 				TargetAttributes = {

--- a/SwiftChart.xcodeproj/project.pbxproj
+++ b/SwiftChart.xcodeproj/project.pbxproj
@@ -194,7 +194,7 @@
 			attributes = {
 				LastSwiftMigration = 0710;
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Giampaolo Bellavite";
 				TargetAttributes = {
 					2404EEAA1A0D5AE800BCB7D6 = {
@@ -320,6 +320,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -388,6 +389,7 @@
 				INFOPLIST_FILE = SwiftChart/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.gbpl.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -402,6 +404,7 @@
 				INFOPLIST_FILE = SwiftChart/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.gbpl.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 			};
@@ -421,6 +424,7 @@
 				);
 				INFOPLIST_FILE = SwiftChartTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.gbpl.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftChart.app/SwiftChart";
 			};
@@ -436,6 +440,7 @@
 				);
 				INFOPLIST_FILE = SwiftChartTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.gbpl.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftChart.app/SwiftChart";
 			};

--- a/SwiftChart/BasicChartViewController.swift
+++ b/SwiftChart/BasicChartViewController.swift
@@ -82,9 +82,9 @@ class BasicChartViewController: UIViewController, ChartDelegate {
     // Chart delegate
     
     func didTouchChart(chart: Chart, indexes: Array<Int?>, x: Float, left: CGFloat) {
-        for (seriesIndex, dataIndex) in enumerate(indexes) {
+        for (seriesIndex, dataIndex) in indexes.enumerate() {
             if let value = chart.valueForSeries(seriesIndex, atIndex: dataIndex) {
-                println("Touched series: \(seriesIndex): data index: \(dataIndex!); series value: \(value); x-axis value: \(x) (from left: \(left))")
+                print("Touched series: \(seriesIndex): data index: \(dataIndex!); series value: \(value); x-axis value: \(x) (from left: \(left))")
             }
         }
     }

--- a/SwiftChart/BasicChartViewController.swift
+++ b/SwiftChart/BasicChartViewController.swift
@@ -21,8 +21,6 @@ class BasicChartViewController: UIViewController, ChartDelegate {
         switch selectedChart {
         case 0:
             
-            let chart2 = Chart(frame: CGRect(x: 0, y: 0, width: 100, height: 200))
-            
             // Simple chart
             let series = ChartSeries([0, 6, 2, 8, 4, 7, 3, 10, 8])
             series.color = ChartColors.greenColor()

--- a/SwiftChart/Info.plist
+++ b/SwiftChart/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.gbpl.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/SwiftChart/TableViewController.swift
+++ b/SwiftChart/TableViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class TableViewController: UITableViewController, UITableViewDelegate {
+class TableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -25,7 +25,7 @@ class TableViewController: UITableViewController, UITableViewDelegate {
     
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue.identifier == "BasicChartSegue" {
-            let indexPath = tableView.indexPathForSelectedRow()
+            let indexPath = tableView.indexPathForSelectedRow
             let dvc = segue.destinationViewController as! BasicChartViewController
             dvc.selectedChart = indexPath!.row
         }

--- a/SwiftChartTests/Info.plist
+++ b/SwiftChartTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>org.gbpl.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
The latest version of Xcode only work with Swift 2.0, so projects will need to use this syntax going forward.