### PR TITLE
Custom threshold for positive/negative data display

### DIFF
--- a/Source/ChartSeries.swift
+++ b/Source/ChartSeries.swift
@@ -16,10 +16,10 @@ open class ChartSeries {
     open var line: Bool = true
     open var color: UIColor = ChartColors.blueColor() {
         didSet {
-            colors = (above: color, below: color)
+            colors = (above: color, below: color, 0)
         }
     }
-    var colors: (above: UIColor, below: UIColor) = (above: ChartColors.blueColor(), below: ChartColors.redColor())
+    open var colors: (above: UIColor, below: UIColor, zeroLevel: Float) = (above: ChartColors.blueColor(), below: ChartColors.redColor(), 0)
 
     public init(_ data: Array<Float>) {
         self.data = []


### PR DESCRIPTION
Introduces feature requested in #43 
The threshold can be set by changing chartSeries.colors.zeroLevel value.

Looks like this:
![screen shot 2016-11-14 at 10 54 20 pm](https://cloud.githubusercontent.com/assets/6792526/20282985/cae49b6c-aabf-11e6-9676-8150e9b22781.png)
with one of sample chart series and
```
series.colors.zeroLevel = -1.5
```