### PR TITLE
Added an option to automatically hide the highlightLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ class MyViewController: UIViewController, ChartDelegate {
     }
     
     func didFinishTouchingChart(chart: Chart) {
-        // Do something when finished
+        // Do something when finished (only called after the user swipes out of the chart either on the right or the left side)
+    }
+    
+    func didEndTouchingChart(chart: Chart) {
+       // Do something when the user ends touching the chart
     }
 }
 ```
@@ -196,6 +200,7 @@ There is no built-in method to update a chart. To accomplish this:
 * `delegate`: the delegate for listening to touch events.
 * `highlightLineColor`: color of the highlight line.
 * `highlightLineWidth`: width of the highlight line.
+* `shouldAutoHideHighlightLine`: automatically hide the highlightLine after we've ended touching the chart.
 * `gridColor`: the grid color.
 * `labelColor`: the color of the labels.
 * `labelFont`: the font used for the labels.

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -29,6 +29,15 @@ public protocol ChartDelegate {
 
     */
     func didFinishTouchingChart(_ chart: Chart)
+    
+    
+    /**
+     Tells the delegate that the user ended touching the chart. The user will "end" touching the chart whenever the touchesDidEnd method is being called. 
+     
+     - parameter chart: The chart that has been touched.
+     
+     */
+    func didEndTouchingChart(_ chart: Chart)
 }
 
 /**
@@ -703,6 +712,7 @@ open class Chart: UIControl {
 
     override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         handleTouchEvents(touches, event: event)
+        delegate?.didEndTouchingChart(self)
     }
 
     override open func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -167,6 +167,11 @@ open class Chart: UIControl {
     Width for the highlight line.
     */
     open var highlightLineWidth: CGFloat = 0.5
+    
+    /**
+     Wether we should automatically hide the highlightLine after touches have ended.
+     */
+    open var shouldAutoHideHighlightLine: Bool = false
 
     /**
     Alpha component for the area's color.
@@ -643,6 +648,8 @@ open class Chart: UIControl {
 
     fileprivate func drawHighlightLineFromLeftPosition(_ left: CGFloat) {
         if let shapeLayer = highlightShapeLayer {
+            shapeLayer.isHidden = false
+            
             // Use line already created
             let path = CGMutablePath()
 
@@ -712,6 +719,7 @@ open class Chart: UIControl {
 
     override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         handleTouchEvents(touches, event: event)
+        highlightShapeLayer?.isHidden = shouldAutoHideHighlightLine
         delegate?.didEndTouchingChart(self)
     }
 

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -171,7 +171,7 @@ open class Chart: UIControl {
     /**
      Wether we should automatically hide the highlightLine after touches have ended.
      */
-    open var shouldAutoHideHighlightLine: Bool = false
+    open var autoHideHighlightLine: Bool = false
 
     /**
     Alpha component for the area's color.
@@ -719,7 +719,7 @@ open class Chart: UIControl {
 
     override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         handleTouchEvents(touches, event: event)
-        highlightShapeLayer?.isHidden = shouldAutoHideHighlightLine
+        highlightShapeLayer?.isHidden = autoHideHighlightLine
         delegate?.didEndTouchingChart(self)
     }
 


### PR DESCRIPTION
I've added an option to automatically hide the highlightLine when the touches on the chart have ended. 

 I needed this option for my particular use-case (I am showing a default message when no part of the graph is selected using the highlightLine).
 I'm not 100% sure if this is the way to implement such a feature, but I thought I would give it a try (and it works as expected)

Furthermore I have updated the documentation in the readme with this property and #62 