### PR TITLE
Optionally hide highlight line on didEndTouchingChart

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Some tips for debugging an hidden chart:
 * `delegate` – the delegate for listening to touch events.
 * `highlightLineColor` – color of the highlight line.
 * `highlightLineWidth` – width of the highlight line.
+* `removesHighlighLineOnTouchesEnded` (default `false`) – if true will hide the highlight line as soon as you stop swiping over the chart.
 * `gridColor` – the grid color.
 * `labelColor` – the color of the labels.
 * `labelFont` – the font used for the labels.

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -194,6 +194,10 @@ open class Chart: UIControl {
     Width for the highlight line.
     */
     open var highlightLineWidth: CGFloat = 0.5
+    /**
+     Removes highlight line when touches end.
+     */
+    open var removesHighlighLineOnTouchesEnded = false
 
     /**
     Alpha component for the area's color.
@@ -756,6 +760,11 @@ open class Chart: UIControl {
 
     override open func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         handleTouchEvents(touches, event: event)
+        if self.removesHighlighLineOnTouchesEnded {
+            if let shapeLayer = highlightShapeLayer {
+                shapeLayer.path = nil
+            }
+        }
         delegate?.didEndTouchingChart(self)
     }
 


### PR DESCRIPTION
As a normal behavior the highlight line stays visible unless the `didFinishTouchingChart` is called, but there are some applications that might need to hide it after `didEndTouchingChart`.
A new boolean property called `removesHighlighLineOnTouchesEnded` will take care of removing the highlight line if true. By default this property is false which does not change the Chart's normal behavior of keeping the line visible when `didEndTouchingChart` is called.