### PR TITLE
Allow programatically finishing chart touches

### DIFF
--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -284,6 +284,17 @@ open class Chart: UIControl {
         return series.data[dataIndex!].y
     }
 
+    /**
+    Finish touching the chart, by removing the highlight line and calling the delegate method.
+    */
+    public func finishTouchingChart() {
+        // Remove highlight line at the end of the touch event
+        if let shapeLayer = highlightShapeLayer {
+            shapeLayer.path = nil
+        }
+        delegate?.didFinishTouchingChart(self)
+    }
+    
     fileprivate func drawIBPlaceholder() {
         let placeholder = UIView(frame: self.frame)
         placeholder.backgroundColor = UIColor(red: 0.93, green: 0.93, blue: 0.93, alpha: 1)
@@ -719,11 +730,7 @@ open class Chart: UIControl {
         let x = valueFromPointAtX(left)
 
         if left < 0 || left > (drawingWidth as CGFloat) {
-            // Remove highlight line at the end of the touch event
-            if let shapeLayer = highlightShapeLayer {
-                shapeLayer.path = nil
-            }
-            delegate?.didFinishTouchingChart(self)
+            finishTouchingChart()
             return
         }
 
@@ -748,8 +755,8 @@ open class Chart: UIControl {
         }
 
         delegate!.didTouchChart(self, indexes: indexes, x: x, left: left)
-
     }
+
     override open func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         handleTouchEvents(touches, event: event)
     }


### PR DESCRIPTION
Currently, when a user touches the chart and you have the highlight line enabled it will appear where they touched, but there is no way to remove this line programatically when they are done or you need this line gone.

This pull adds `finishTouchingChart()`, which will remove the line for you and call the delegate method `didFinishTouchingChart()`. It also modifies the touch handling code to use this method internally.