### PR TITLE
Accessibility & VoiceOver support

### DIFF
--- a/Example/SwiftChart/StockChartViewController.swift
+++ b/Example/SwiftChart/StockChartViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import SwiftChart
 
 class StockChartViewController: UIViewController, ChartDelegate {
     
@@ -35,6 +34,7 @@ class StockChartViewController: UIViewController, ChartDelegate {
         var serieData: [Double] = []
         var labels: [Double] = []
         var labelsAsString: Array<String> = []
+        var accessibilityXLabels: [String] = []
         
         // Date formatter to retrieve the month names
         let dateFormatter = DateFormatter()
@@ -51,6 +51,11 @@ class StockChartViewController: UIViewController, ChartDelegate {
                 labels.append(Double(i))
                 labelsAsString.append(monthAsString)
             }
+            
+            let xFormatter = DateFormatter()
+            xFormatter.dateStyle = .medium
+            let xDescription = xFormatter.string(from: value["date"] as! Date)
+            accessibilityXLabels.append(xDescription)
         }
         
         let series = ChartSeries(serieData)
@@ -60,6 +65,7 @@ class StockChartViewController: UIViewController, ChartDelegate {
         
         chart.lineWidth = 0.5
         chart.labelFont = UIFont.systemFont(ofSize: 12)
+        chart.accessibilityXLabels = accessibilityXLabels
         chart.xLabels = labels
         chart.xLabelsFormatter = { (labelIndex: Int, labelValue: Double) -> String in
             return labelsAsString[labelIndex]

--- a/Example/SwiftChart/StockChartViewController.swift
+++ b/Example/SwiftChart/StockChartViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SwiftChart
 
 class StockChartViewController: UIViewController, ChartDelegate {
     
@@ -52,6 +53,7 @@ class StockChartViewController: UIViewController, ChartDelegate {
                 labelsAsString.append(monthAsString)
             }
             
+            // Create a slightly more descriptive x-label for Accessibility/VoiceOver
             let xFormatter = DateFormatter()
             xFormatter.dateStyle = .medium
             let xDescription = xFormatter.string(from: value["date"] as! Date)
@@ -61,6 +63,7 @@ class StockChartViewController: UIViewController, ChartDelegate {
         let series = ChartSeries(serieData)
         series.area = true
         
+        // Since we know the values are in Dollars, we can improve the experience for VoiceOver users by simply setting y-labels
         let accessibilityYLabels = serieData.map { "$\($0)" }
         
         // Configure chart layout

--- a/Example/SwiftChart/StockChartViewController.swift
+++ b/Example/SwiftChart/StockChartViewController.swift
@@ -61,11 +61,14 @@ class StockChartViewController: UIViewController, ChartDelegate {
         let series = ChartSeries(serieData)
         series.area = true
         
+        let accessibilityYLabels = serieData.map { "$\($0)" }
+        
         // Configure chart layout
         
         chart.lineWidth = 0.5
         chart.labelFont = UIFont.systemFont(ofSize: 12)
         chart.accessibilityXLabels = accessibilityXLabels
+        chart.accessibilityYLabels = accessibilityYLabels
         chart.xLabels = labels
         chart.xLabelsFormatter = { (labelIndex: Int, labelValue: Double) -> String in
             return labelsAsString[labelIndex]

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -562,7 +562,7 @@ open class Chart: UIControl {
         let path = CGMutablePath()
         path.move(to: CGPoint(x: CGFloat(xValues.first!), y: CGFloat(yValues.first!)))
         
-        // Since drawing starts from the second point, create an accessibility element for the first data point.
+        // Since drawing starts from the second point, create an accessibility element for the first data point here, before the loop.
         var dataSetIndexOffset: Int = 0
         let counts = self.accessibilityChartDataIndices.map { $0.count }
 
@@ -581,6 +581,7 @@ open class Chart: UIControl {
         // This offset is used to compute the correct index into the data based on the number of valid data points already generated in prior segments.
         dataSetIndexOffset += segmentIndex > 0  && counts.count > 1 ? counts[0..<segmentIndex].reduce(0, +) - 1 : 0
         
+        // Using the above, generate accessibilityElements for each data point
         for i in 1..<yValues.count {
             let x = CGFloat(xValues[i])
             let y = CGFloat(yValues[i])
@@ -1017,6 +1018,10 @@ open class Chart: UIControl {
         
         // The indices of data points are relative to the original data array.
         // This removes traversed element counts from earlier segment indices to make each index relative to the segment the data point occurs in.
+        // For example, instead of an an array like
+        // [Set(2, 0, 1), Set(3), Set(4)]
+        // We want an array that looks like
+        // [Set(2, 0, 1), Set(1), Set(1)]
         var previousElementsOffset: Int = accessibilityIndices.first?.count ?? 0
         for (i, indexSet) in accessibilityIndices.enumerated() {
             guard i > 0 else { continue }

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -484,6 +484,20 @@ open class Chart: UIControl {
     
     fileprivate var accessibilityChartDataIndices: [Set<Int>] = []
     
+    /**
+     Labels that better describe the X component of all values.
+     
+     **NOTE**: Ensure that its count is the same as the number of data points / y values.
+    */
+    open var accessibilityXLabels: [String]?
+
+    /**
+     Labels to describe each Y value differently than the raw value.
+     
+     **NOTE**: Ensure that its count is the same as the number of data points / x values.
+     */
+    open var accessibilityYLabels: [String]?
+    
     open override var isAccessibilityElement: Bool {
         get { return false }
         set { }
@@ -507,7 +521,7 @@ open class Chart: UIControl {
                                                 y: CGFloat,
                                                dataValueIndex index: Int,
                                                indexOffset offset: Int = 0) -> UIAccessibilityElement {
-        // Note: This creates the accessibility element with each side 44.0 units since it is doubled
+        // Create the accessibility element with each side 44.0 units
         let dimension: CGFloat = 22.0
 
         let rect = CGRect(x: x - dimension,
@@ -518,8 +532,22 @@ open class Chart: UIControl {
         let ax = series[seriesIndex].data[index + offset].x
         let ay = series[seriesIndex].data[index + offset].y
         
+        // If x or y accessibilityLabels have been set, then use those otherwise default to raw values.
+        var labelDescription: String = ""
+        if let accessibilityXLabels = self.accessibilityXLabels {
+            labelDescription += "\(accessibilityXLabels[index + offset])"
+        } else {
+            labelDescription += String(format: " x: %.2f", ax)
+        }
+        
+        if let accessibilityYLabels = self.accessibilityYLabels {
+            labelDescription += ", \(accessibilityYLabels[index + offset])"
+        } else {
+            labelDescription += String(format: ", y: %.2f", ay)
+        }
+        
         let element = UIAccessibilityElement(accessibilityContainer: self)
-        element.accessibilityLabel = "Dataset \(seriesIndex + 1):" + String(format: " x: %.2f, y: %.2f", ax, ay)
+        element.accessibilityLabel = "Dataset \(seriesIndex + 1):" + labelDescription
         element.accessibilityFrame = self.convert(rect, to: UIScreen.main.coordinateSpace)
         
         return element

--- a/Source/Chart.swift
+++ b/Source/Chart.swift
@@ -502,6 +502,29 @@ open class Chart: UIControl {
         return self.accessibilityChartElements.index(of: chartElement) ?? NSNotFound
     }
     
+    fileprivate func createAccessibilityElement(forSeriesIndex seriesIndex: Int,
+                                                withX x: CGFloat,
+                                                y: CGFloat,
+                                               dataValueIndex index: Int,
+                                               indexOffset offset: Int = 0) -> UIAccessibilityElement {
+        // Note: This creates the accessibility element with each side 44.0 units since it is doubled
+        let dimension: CGFloat = 22.0
+
+        let rect = CGRect(x: x - dimension,
+                          y: y - dimension,
+                          width: 2 * dimension,
+                          height: 2 * dimension)
+        
+        let ax = series[seriesIndex].data[index + offset].x
+        let ay = series[seriesIndex].data[index + offset].y
+        
+        let element = UIAccessibilityElement(accessibilityContainer: self)
+        element.accessibilityLabel = "Dataset \(seriesIndex + 1):" + String(format: " x: %.2f, y: %.2f", ax, ay)
+        element.accessibilityFrame = self.convert(rect, to: UIScreen.main.coordinateSpace)
+        
+        return element
+    }
+    
     // MARK: - Drawings
 
     fileprivate func drawLine(_ xValues: [Double], yValues: [Double], seriesIndex: Int, segmentIndex: Int) {
@@ -511,24 +534,17 @@ open class Chart: UIControl {
         path.move(to: CGPoint(x: CGFloat(xValues.first!), y: CGFloat(yValues.first!)))
         
         // Since drawing starts from the second point, create an accessibility element for the first data point.
-        let dimension: CGFloat = 9.0
         var dataSetIndexOffset: Int = 0
         let counts = self.accessibilityChartDataIndices.map { $0.count }
 
         // If we're drawing the first segment, then generate an element.
         // Otherwise, the first element is a separation point between positive/negative
         if self.accessibilityChartDataIndices[segmentIndex].contains(0) {
-            let rect = CGRect(x: CGFloat(xValues.first!) - dimension,
-                              y: CGFloat(yValues.first!) - dimension,
-                              width: 2 * dimension,
-                              height: 2 * dimension)
             
-            let ax = series[seriesIndex].data.first!.x
-            let ay = series[seriesIndex].data.first!.y
-            
-            let element = UIAccessibilityElement(accessibilityContainer: self)
-            element.accessibilityLabel = String(format: "%.2f, %.2f", ax, ay)
-            element.accessibilityFrame = self.convert(rect, to: UIScreen.main.coordinateSpace)
+            let element = self.createAccessibilityElement(forSeriesIndex: seriesIndex,
+                                                          withX: CGFloat(xValues.first!),
+                                                          y: CGFloat(yValues.first!),
+                                                          dataValueIndex: 0)
             
             self.accessibilityChartElements.append(element)
         }
@@ -543,20 +559,14 @@ open class Chart: UIControl {
             
             // If the current index is not a separation point on the zero line, then generate an accessibility point
             if self.accessibilityChartDataIndices[segmentIndex].contains(i) {
-                let rect = CGRect(x: x - dimension,
-                                  y: y - dimension,
-                                  width: 2 * dimension,
-                                  height: 2 * dimension)
-                
-                let ax = series[seriesIndex].data[i + dataSetIndexOffset].x
-                let ay = series[seriesIndex].data[i + dataSetIndexOffset].y
 
-                let element = UIAccessibilityElement(accessibilityContainer: self)
-                element.accessibilityLabel = "Dataset \(seriesIndex + 1):" + String(format: " x: %.2f, y: %.2f", ax, ay)
-                element.accessibilityFrame = self.convert(rect, to: UIScreen.main.coordinateSpace)
+                let element = self.createAccessibilityElement(forSeriesIndex: seriesIndex,
+                                                              withX: x,
+                                                              y: y,
+                                                              dataValueIndex: i,
+                                                              indexOffset: dataSetIndexOffset)
                 
                 self.accessibilityChartElements.append(element)
-                
             }
         }
 


### PR DESCRIPTION
Hello! Thanks for the library.

I noticed that currently, SwiftCharts isn't accessible to VoiceOver and other clients that use UIAccessibility. You can test this by turning on VoiceOver and running the example project, where it currently defaults to reading the X and Y axes labels.

This PR attempts to address this issue, by making the data contained in each chart accessible, using the UIAccessibilityContainer protocol. I've attempted to minimize changes to rendering and structure and have left comments describing additions. Changes are apparent when using the example project with VoiceOver running, otherwise there should be no visible changes. I've added 2 additional public properties: ```accessibilityXLabels``` and ```accessibilityYLabels```. These allow the customization of labels to sound better to an audio interface. I've updated the StockChartsViewController to make use of both of them to demonstrate its effect.

Happy to make any changes!